### PR TITLE
Fix sqlcipher compatibility issue

### DIFF
--- a/tools/decrypt_db_with_password.py
+++ b/tools/decrypt_db_with_password.py
@@ -17,6 +17,7 @@ try:
     c = conn.cursor()
 
     c.execute("PRAGMA key = '" + key + "';")
+    c.execute("PRAGMA cipher_compatibility = 1;")
     c.execute("PRAGMA cipher_use_hmac = OFF;")
     c.execute("PRAGMA cipher_page_size = 1024;")
     c.execute("PRAGMA kdf_iter = 4000;")


### PR DESCRIPTION
This PR is to solve #12. Without the `cipher_compatibility = 1` set, the driver would report `file is not a database` error even with the correct password.